### PR TITLE
Add "PayloadVersion" to top-level payload keys

### DIFF
--- a/pfm2template/pfm2template.py
+++ b/pfm2template/pfm2template.py
@@ -17,6 +17,7 @@ def generate_payload(data, result):
     result['PayloadIdentifier'] = '{}.example'.format(data.get('pfm_domain', 'domain.undefined'))
     result['PayloadDisplayName'] = 'Example: {}'.format(data.get('pfm_title'), 'No Title')
     result['PayloadDescription'] = 'Example: {}'.format(data.get('pfm_description'), 'No Description')
+    result['PayloadVersion'] = '1'
     result['PayloadContent'] = [{}]
     generate(data['pfm_subkeys'], result['PayloadContent'][0])
 
@@ -29,6 +30,7 @@ def generate_dict(data, result):
         result['PayloadIdentifier'] = '{}.example'.format(data.get('pfm_domain', 'domain.undefined'))
         result['PayloadDisplayName'] = 'Example: {}'.format(data.get('pfm_title'), 'No Title')
         result['PayloadDescription'] = 'Example: {}'.format(data.get('pfm_description'), 'No Description')
+        result['PayloadVersion'] = '1'
         result['PayloadContent'] = [{}]
 
         generate(data['pfm_subkeys'], result['PayloadContent'][0])


### PR DESCRIPTION
Add "PayloadVersion" to top-level payload keys to comply with [Apple's Configuration Profile Reference Sample Configuration Profile](https://developer.apple.com/library/content/featuredarticles/iPhoneConfigurationProfileRef/Introduction/Introduction.html#//apple_ref/doc/uid/TP40010206-CH1-SW3).